### PR TITLE
Start/Stop a pod from virtc command line

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -127,4 +127,7 @@ type agent interface {
 
 	// stopPod will tell the agent to stop all containers related to the Pod.
 	stopPod(config PodConfig) error
+
+	// stop will stop the agent on the host.
+	stop() error
 }

--- a/api.go
+++ b/api.go
@@ -37,6 +37,11 @@ func CreatePod(podConfig PodConfig) (*Pod, error) {
 		return nil, err
 	}
 
+	err = p.endSession()
+	if err != nil {
+		return nil, err
+	}
+
 	return p, nil
 }
 
@@ -51,6 +56,11 @@ func DeletePod(podID string) (*Pod, error) {
 
 	// Delete it.
 	err = p.delete()
+	if err != nil {
+		return nil, err
+	}
+
+	err = p.endSession()
 	if err != nil {
 		return nil, err
 	}
@@ -76,6 +86,11 @@ func StartPod(podID string) (*Pod, error) {
 		return nil, err
 	}
 
+	err = p.endSession()
+	if err != nil {
+		return nil, err
+	}
+
 	return p, nil
 }
 
@@ -92,6 +107,11 @@ func StopPod(podID string) (*Pod, error) {
 	err = p.stop()
 	if err != nil {
 		p.delete()
+		return nil, err
+	}
+
+	err = p.endSession()
+	if err != nil {
 		return nil, err
 	}
 
@@ -117,6 +137,11 @@ func RunPod(podConfig PodConfig) (*Pod, error) {
 	err = p.start()
 	if err != nil {
 		p.delete()
+		return nil, err
+	}
+
+	err = p.endSession()
+	if err != nil {
 		return nil, err
 	}
 

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -78,6 +78,15 @@ const (
 	ttyType
 )
 
+// List of channels name according
+const (
+	// chCtlName is the name of the control channel for hyperstart.
+	chCtlName = "sh.hyper.channel.0"
+
+	// chTtyName is the name of the tty channel for hyperstart.
+	chTtyName = "sh.hyper.channel.1"
+)
+
 // HyperConfig is a structure storing information needed for
 // hyperstart agent initialization.
 type HyperConfig struct {
@@ -400,6 +409,28 @@ func (h *hyper) init(config interface{}, hypervisor hypervisor) error {
 
 	for _, sharedDir := range h.config.Volumes {
 		err := h.hypervisor.addDevice(sharedDir, fsDev)
+		if err != nil {
+			return err
+		}
+	}
+
+	sockets := []Socket{
+		{
+			DeviceID: "channel0",
+			ID:       "charch0",
+			HostPath: h.config.SockCtlName,
+			Name:     chCtlName,
+		},
+		{
+			DeviceID: "channel1",
+			ID:       "charch1",
+			HostPath: h.config.SockTtyName,
+			Name:     chTtyName,
+		},
+	}
+
+	for _, socket := range sockets {
+		err := h.hypervisor.addDevice(socket, serialPortDev)
 		if err != nil {
 			return err
 		}

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -105,11 +105,11 @@ type frame struct {
 	payload    string
 }
 
-// execInfo is the structure corresponding to the format
+// ExecInfo is the structure corresponding to the format
 // expected by hyperstart to execute a command on the guest.
-type execInfo struct {
-	container string
-	process   hyperJson.Process
+type ExecInfo struct {
+	Container string            `json:"container"`
+	Process   hyperJson.Process `json:"process"`
 }
 
 func (c HyperConfig) validate() bool {
@@ -436,9 +436,9 @@ func (h *hyper) exec(podID string, contID string, cmd Cmd) error {
 		return err
 	}
 
-	execInfo := execInfo{
-		container: contID,
-		process:   process,
+	execInfo := ExecInfo{
+		Container: contID,
+		Process:   process,
 	}
 
 	err = sendCmd(h.cCtl, execCommand, execInfo)

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -498,3 +498,28 @@ func (h *hyper) stopPod(config PodConfig) error {
 
 	return nil
 }
+
+// stop is the agent stopping implementation for hyperstart.
+func (h *hyper) stop() error {
+	if h.cCtl == nil {
+		return fmt.Errorf("Cannot close CTL channel, fd is nil")
+	}
+
+	err := h.cCtl.Close()
+	if err != nil {
+		return err
+	}
+	h.cCtl = nil
+
+	if h.cTty == nil {
+		return fmt.Errorf("Cannot close TTY channel, fd is nil")
+	}
+
+	err = h.cTty.Close()
+	if err != nil {
+		return err
+	}
+	h.cTty = nil
+
+	return nil
+}

--- a/hypervisor.go
+++ b/hypervisor.go
@@ -52,6 +52,9 @@ const (
 
 	// ConsoleDev is the console device type.
 	consoleDev
+
+	// SerialPortDev is the serial port device type.
+	serialPortDev
 )
 
 // Set sets an hypervisor type based on the input string.

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -45,3 +45,8 @@ func (n *noopAgent) startPod(config PodConfig) error {
 func (n *noopAgent) stopPod(config PodConfig) error {
 	return nil
 }
+
+// stop is the Noop agent stopping implementation. It does nothing.
+func (n *noopAgent) stop() error {
+	return nil
+}

--- a/pod.go
+++ b/pod.go
@@ -182,6 +182,59 @@ func (v *Volumes) String() string {
 	return strings.Join(volSlice, " ")
 }
 
+// Socket defines a socket to communicate between
+// the host and any process inside the VM.
+type Socket struct {
+	DeviceID string
+	ID       string
+	HostPath string
+	Name     string
+}
+
+// Sockets is a Socket list.
+type Sockets []Socket
+
+// Set assigns socket values from string to a Socket.
+func (s *Sockets) Set(sockStr string) error {
+	sockSlice := strings.Split(sockStr, " ")
+
+	for _, sock := range sockSlice {
+		sockArgs := strings.Split(sock, ":")
+
+		if len(sockArgs) != 4 {
+			return fmt.Errorf("Wrong string format: %s, expecting only 4 parameters separated with ':'", sock)
+		}
+
+		for _, a := range sockArgs {
+			if a == "" {
+				return fmt.Errorf("Socket parameters cannot be empty")
+			}
+		}
+
+		socket := Socket{
+			DeviceID: sockArgs[0],
+			ID:       sockArgs[1],
+			HostPath: sockArgs[2],
+			Name:     sockArgs[3],
+		}
+
+		*s = append(*s, socket)
+	}
+
+	return nil
+}
+
+// String converts a Socket to a string.
+func (s *Sockets) String() string {
+	var sockSlice []string
+
+	for _, sock := range *s {
+		sockSlice = append(sockSlice, fmt.Sprintf("%s:%s:%s:%s", sock.DeviceID, sock.ID, sock.HostPath, sock.Name))
+	}
+
+	return strings.Join(sockSlice, " ")
+}
+
 // EnvVar is a key/value structure representing a command
 // environment variable.
 type EnvVar struct {
@@ -234,6 +287,10 @@ type PodConfig struct {
 
 	// Volumes is a list of shared volumes between the host and the Pod.
 	Volumes []Volume
+
+	// Sockets is a list of sockets to allowing the communication
+	// between the host and the Pod.
+	Sockets []Socket
 
 	// Containers describe the list of containers within a Pod.
 	// This list can be empty and populated by adding containers

--- a/pod.go
+++ b/pod.go
@@ -812,6 +812,11 @@ func (p *Pod) stop() error {
 		return err
 	}
 
+	err = p.agent.stop()
+	if err != nil {
+		return err
+	}
+
 	err = p.hypervisor.stopPod()
 	if err != nil {
 		return err

--- a/pod.go
+++ b/pod.go
@@ -853,3 +853,13 @@ func (p *Pod) setState(state stateString) error {
 
 	return nil
 }
+
+// endSession makes sure to end the session properly.
+func (p *Pod) endSession() error {
+	err := p.agent.stop()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/qemu.go
+++ b/qemu.go
@@ -470,7 +470,7 @@ func (q *qemu) stopPod() error {
 		return err
 	}
 
-	return qmp.ExecuteSystemPowerdown(q.qmpMonitorCh.ctx)
+	return qmp.ExecuteQuit(q.qmpMonitorCh.ctx)
 }
 
 // addDevice will add extra devices to Qemu command line.

--- a/qemu.go
+++ b/qemu.go
@@ -192,7 +192,7 @@ func (q *qemu) appendConsoles(devices []ciaoQemu.Device, podConfig PodConfig) []
 	for i, c := range podConfig.Containers {
 		var console ciaoQemu.CharDevice
 		if c.Interactive == false || c.Console == "" {
-			consolePath := fmt.Sprintf("%s%s/console.sock", runStoragePath, podConfig.ID)
+			consolePath := fmt.Sprintf("%s/%s/console.sock", runStoragePath, podConfig.ID)
 
 			console = ciaoQemu.CharDevice{
 				Driver:   ciaoQemu.Console,

--- a/sshd.go
+++ b/sshd.go
@@ -157,3 +157,8 @@ func (s *sshd) startPod(config PodConfig) error {
 func (s *sshd) stopPod(config PodConfig) error {
 	return nil
 }
+
+// stop is the agent stopping implementation for sshd.
+func (s *sshd) stop() error {
+	return nil
+}

--- a/virtc/main.go
+++ b/virtc/main.go
@@ -146,8 +146,16 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 		interactive = true
 	}
 
+	envs := []vc.EnvVar{
+		{
+			Var:   "PATH",
+			Value: "/bin:/usr/bin:/sbin:/usr/sbin",
+		},
+	}
+
 	cmd := vc.Cmd{
-		Args:    []string{"/bin/bash", "echo", "hello"},
+		Args:    []string{"echo", "hello"},
+		Envs:    envs,
 		WorkDir: "/",
 	}
 

--- a/virtc/main.go
+++ b/virtc/main.go
@@ -106,6 +106,12 @@ var podConfigFlags = []cli.Flag{
 		Value: new(vc.Volumes),
 		Usage: "the volume to be shared with VM",
 	},
+
+	cli.GenericFlag{
+		Name:  "socket",
+		Value: new(vc.Sockets),
+		Usage: "the socket list to be shared with VM",
+	},
 }
 
 func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
@@ -134,6 +140,11 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	volumes, ok := context.Generic("volume").(*vc.Volumes)
 	if ok != true {
 		return vc.PodConfig{}, fmt.Errorf("Could not convert to volume list")
+	}
+
+	sockets, ok := context.Generic("socket").(*vc.Sockets)
+	if ok != true {
+		return vc.PodConfig{}, fmt.Errorf("Could not convert to socket list")
 	}
 
 	u, _ := user.Current()
@@ -205,6 +216,8 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 
 		AgentType:   *agentType,
 		AgentConfig: agConfig,
+
+		Sockets: *sockets,
 
 		Containers: containers,
 	}


### PR DESCRIPTION
With those patches, we are able to start/stop a pod, using the virtc command line. It uses Qemu + Hyperstart combination.
It fixes issue #9 as we are able to use the hyperstart protocol.
