### PR TITLE
Specify VM resources for each pod configuration

### DIFF
--- a/hyperstart_test.go
+++ b/hyperstart_test.go
@@ -1,0 +1,171 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"math/rand"
+	"net"
+	"testing"
+
+	"github.com/01org/cc-oci-runtime/tests/mock"
+)
+
+func connectHyperstart(t *testing.T) (*mock.Hyperstart, net.Conn, net.Conn, error) {
+	h := mock.NewHyperstart(t)
+
+	h.Start()
+
+	ctlSock, ttySock := h.GetSocketPaths()
+
+	cCtl, err := net.Dial("unix", ctlSock)
+	if err != nil {
+		h.Stop()
+		return nil, nil, nil, err
+	}
+
+	cTty, err := net.Dial("unix", ttySock)
+	if err != nil {
+		cCtl.Close()
+		h.Stop()
+		return nil, nil, nil, err
+	}
+
+	return h, cCtl, cTty, nil
+}
+
+func disconnectHyperstart(cCtl, cTty net.Conn) {
+	cTty.Close()
+	cCtl.Close()
+}
+
+func testHyperstartSendCmd(t *testing.T, cmdID string, payload interface{}) {
+	h, cCtl, cTty, err := connectHyperstart(t)
+	if err != nil {
+		t.Fatal()
+	}
+
+	defer h.Stop()
+	defer disconnectHyperstart(cCtl, cTty)
+
+	err = sendCmd(cCtl, cmdID, payload)
+	if err != nil {
+		t.Fatal()
+	}
+}
+
+var cmdList = []string{
+	getVersion,
+	startPod,
+	getPod,
+	restartContainer,
+	execCommand,
+	cmdFinished,
+	ready,
+	ack,
+	hyperError,
+	winSize,
+	ping,
+	podFinished,
+	next,
+	newContainer,
+	killContainer,
+	onlineCPUMem,
+	setupInterface,
+	setupRoute,
+}
+
+func TestHyperstartSendCmd(t *testing.T) {
+	for _, cmd := range cmdList {
+		testHyperstartSendCmd(t, cmd, nil)
+	}
+}
+
+func testHyperstartSendSeq(t *testing.T, seq uint64, payload string) {
+	h, cCtl, cTty, err := connectHyperstart(t)
+	if err != nil {
+		t.Fatal()
+	}
+
+	defer h.Stop()
+	defer disconnectHyperstart(cCtl, cTty)
+
+	err = sendSeq(cTty, seq, payload)
+	if err != nil {
+		t.Fatal()
+	}
+
+	buf := make([]byte, 512)
+	n, recvSeq := h.ReadIo(buf)
+
+	recvPayload := string(buf[ttyHdrSize:n])
+	if recvSeq != seq || recvPayload != payload {
+		t.Fatal()
+	}
+}
+
+func TestHyperstartSendSeqHello(t *testing.T) {
+	testHyperstartSendSeq(t, uint64(rand.Int63()), "hello")
+}
+
+func testHyperstartWaitForReply(t *testing.T, cmdID string, payload interface{}) {
+	var payloadStr string
+
+	h, cCtl, cTty, err := connectHyperstart(t)
+	if err != nil {
+		t.Fatal()
+	}
+
+	defer h.Stop()
+	defer disconnectHyperstart(cCtl, cTty)
+
+	if payload != nil {
+		jsonOut, err := json.Marshal(payload)
+		if err != nil {
+			t.Fatal()
+		}
+
+		payloadStr = string(jsonOut)
+	} else {
+		payloadStr = ""
+	}
+
+	payloadLen := make([]byte, ctlHdrSize-ctlHdrLenOffset)
+	length := len(payloadStr) + ctlHdrSize
+	binary.BigEndian.PutUint32(payloadLen, uint32(length))
+
+	frame := frame{
+		cmd:        cmdID,
+		payloadLen: string(payloadLen),
+		payload:    payloadStr,
+	}
+
+	err = send(cCtl, frame)
+	if err != nil {
+		t.Fatal()
+	}
+
+	err = waitForReply(cCtl, ack)
+	if err != nil {
+		t.Fatal()
+	}
+}
+
+func TestHyperstartWaitForReplyToPingCmd(t *testing.T) {
+	testHyperstartWaitForReply(t, ping, nil)
+}

--- a/nsenter_test.go
+++ b/nsenter_test.go
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"strings"
+	"testing"
+)
+
+func testNsEnterFormatArgs(t *testing.T, args []string, expected string) {
+	nsenter := &nsenter{}
+
+	cmd, err := nsenter.formatArgs(args)
+	if err != nil {
+		t.Fatal()
+	}
+
+	if strings.Join(cmd, " ") != expected {
+		t.Fatal()
+	}
+}
+
+func TestNsEnterFormatArgsHello(t *testing.T) {
+	expectedCmd := "nsenter --target -1 --mount --uts --ipc --net --pid echo hello"
+
+	args := []string{"echo", "hello"}
+
+	testNsEnterFormatArgs(t, args, expectedCmd)
+}

--- a/pod.go
+++ b/pod.go
@@ -286,6 +286,20 @@ type Cmd struct {
 	Group string
 }
 
+// HardwareConfig describes VM resources configuration.
+type HardwareConfig struct {
+	// Related to processor resources
+	CPUs    string
+	Cores   string
+	Sockets string
+	Threads string
+
+	// Related to memory resources
+	MemSize  string
+	MemSlots string
+	MemMax   string
+}
+
 // ContainerConfig describes one container runtime configuration.
 type ContainerConfig struct {
 	ID string
@@ -306,6 +320,9 @@ type ContainerConfig struct {
 // PodConfig is a Pod configuration.
 type PodConfig struct {
 	ID string
+
+	// VMConfig is the VM configuration to set for this pod.
+	VMConfig HardwareConfig
 
 	HypervisorType   HypervisorType
 	HypervisorConfig HypervisorConfig

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -1,0 +1,521 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	ciaoQemu "github.com/01org/ciao/qemu"
+)
+
+const (
+	testQemuKernelPath = testDir + testKernel
+	testQemuImagePath  = testDir + testImage
+	testQemuPath       = testDir + testHypervisor
+)
+
+func newQemuConfig() HypervisorConfig {
+	return HypervisorConfig{
+		KernelPath:     testQemuKernelPath,
+		ImagePath:      testQemuImagePath,
+		HypervisorPath: testQemuPath,
+	}
+}
+
+func testQemuBuildKernelParams(t *testing.T, kernelParams []Param, expected string) {
+	qemuConfig := newQemuConfig()
+	qemuConfig.KernelParams = kernelParams
+
+	q := &qemu{}
+
+	err := q.buildKernelParams(qemuConfig)
+	if err != nil {
+		t.Fatal()
+	}
+
+	if strings.Join(q.kernelParams, " ") != expected {
+		t.Fatal()
+	}
+}
+
+var testQemuKernelParams = "root=/dev/pmem0p1 rootflags=dax,data=ordered,errors=remount-ro rw rootfstype=ext4 tsc=reliable no_timer_check rcupdate.rcu_expedited=1 i8042.direct=1 i8042.dumbkbd=1 i8042.nopnp=1 i8042.noaux=1 noreplace-smp reboot=k panic=1 console=hvc0 console=hvc1 initcall_debug init=/usr/lib/systemd/systemd systemd.unit=container.target iommu=off quiet systemd.mask=systemd-networkd.service systemd.mask=systemd-networkd.socket systemd.show_status=false cryptomgr.notests"
+
+func TestQemuBuildKernelParamsFoo(t *testing.T) {
+	expectedOut := testQemuKernelParams + " foo=foo bar=bar"
+
+	params := []Param{
+		{
+			parameter: "foo",
+			value:     "foo",
+		},
+		{
+			parameter: "bar",
+			value:     "bar",
+		},
+	}
+
+	testQemuBuildKernelParams(t, params, expectedOut)
+}
+
+func testQemuAppend(t *testing.T, structure interface{}, expected []ciaoQemu.Device, devType deviceType) {
+	var devices []ciaoQemu.Device
+	q := &qemu{}
+
+	switch s := structure.(type) {
+	case Volume:
+		devices = q.appendVolume(devices, s)
+	case Socket:
+		devices = q.appendSocket(devices, s)
+	case PodConfig:
+		switch devType {
+		case serialPortDev:
+			devices = q.appendSockets(devices, s)
+		case fsDev:
+			devices = q.appendFSDevices(devices, s)
+		case consoleDev:
+			devices = q.appendConsoles(devices, s)
+		}
+	}
+
+	if reflect.DeepEqual(devices, expected) == false {
+		t.Fatal()
+	}
+}
+
+func TestQemuAppendVolume(t *testing.T) {
+	mountTag := "testMountTag"
+	hostPath := "testHostPath"
+
+	expectedOut := []ciaoQemu.Device{
+		ciaoQemu.FSDevice{
+			Driver:        ciaoQemu.Virtio9P,
+			FSDriver:      ciaoQemu.Local,
+			ID:            fmt.Sprintf("extra-%s-9p", mountTag),
+			Path:          hostPath,
+			MountTag:      mountTag,
+			SecurityModel: ciaoQemu.None,
+		},
+	}
+
+	volume := Volume{
+		MountTag: mountTag,
+		HostPath: hostPath,
+	}
+
+	testQemuAppend(t, volume, expectedOut, -1)
+}
+
+func TestQemuAppendSocket(t *testing.T) {
+	deviceID := "channelTest"
+	id := "charchTest"
+	hostPath := "/tmp/hyper_test.sock"
+	name := "sh.hyper.channel.test"
+
+	expectedOut := []ciaoQemu.Device{
+		ciaoQemu.CharDevice{
+			Driver:   ciaoQemu.VirtioSerialPort,
+			Backend:  ciaoQemu.Socket,
+			DeviceID: deviceID,
+			ID:       id,
+			Path:     hostPath,
+			Name:     name,
+		},
+	}
+
+	socket := Socket{
+		DeviceID: deviceID,
+		ID:       id,
+		HostPath: hostPath,
+		Name:     name,
+	}
+
+	testQemuAppend(t, socket, expectedOut, -1)
+}
+
+func TestQemuAppendSockets(t *testing.T) {
+	deviceID := "channelTest"
+	id := "charchTest"
+	hostPath := "/tmp/hyper_test.sock"
+	name := "sh.hyper.channel.test"
+
+	expectedOut := []ciaoQemu.Device{
+		ciaoQemu.CharDevice{
+			Driver:   ciaoQemu.VirtioSerialPort,
+			Backend:  ciaoQemu.Socket,
+			DeviceID: fmt.Sprintf("%s.1", deviceID),
+			ID:       fmt.Sprintf("%s.1", id),
+			Path:     fmt.Sprintf("%s.1", hostPath),
+			Name:     fmt.Sprintf("%s.1", name),
+		},
+		ciaoQemu.CharDevice{
+			Driver:   ciaoQemu.VirtioSerialPort,
+			Backend:  ciaoQemu.Socket,
+			DeviceID: fmt.Sprintf("%s.2", deviceID),
+			ID:       fmt.Sprintf("%s.2", id),
+			Path:     fmt.Sprintf("%s.2", hostPath),
+			Name:     fmt.Sprintf("%s.2", name),
+		},
+	}
+
+	sockets := Sockets{
+		{
+			DeviceID: fmt.Sprintf("%s.1", deviceID),
+			ID:       fmt.Sprintf("%s.1", id),
+			HostPath: fmt.Sprintf("%s.1", hostPath),
+			Name:     fmt.Sprintf("%s.1", name),
+		},
+		{
+			DeviceID: fmt.Sprintf("%s.2", deviceID),
+			ID:       fmt.Sprintf("%s.2", id),
+			HostPath: fmt.Sprintf("%s.2", hostPath),
+			Name:     fmt.Sprintf("%s.2", name),
+		},
+	}
+
+	podConfig := PodConfig{
+		Sockets: sockets,
+	}
+
+	testQemuAppend(t, podConfig, expectedOut, serialPortDev)
+}
+
+func TestQemuAppendFSDevices(t *testing.T) {
+	podID := "testPodID"
+	podRootFs := "testPodRootFs"
+	contID := "testContID"
+	contRootFs := "testContRootFs"
+	volMountTag := "testVolMountTag"
+	volHostPath := "testVolHostPath"
+
+	expectedOut := []ciaoQemu.Device{
+		ciaoQemu.FSDevice{
+			Driver:        ciaoQemu.Virtio9P,
+			FSDriver:      ciaoQemu.Local,
+			ID:            fmt.Sprintf("pod-%s-9p", podID),
+			Path:          podRootFs,
+			MountTag:      fmt.Sprintf("pod-rootfs-%s", podID),
+			SecurityModel: ciaoQemu.None,
+		},
+		ciaoQemu.FSDevice{
+			Driver:        ciaoQemu.Virtio9P,
+			FSDriver:      ciaoQemu.Local,
+			ID:            fmt.Sprintf("ctr-%s-9p", fmt.Sprintf("%s.1", contID)),
+			Path:          fmt.Sprintf("%s.1", contRootFs),
+			MountTag:      "rootfs",
+			SecurityModel: ciaoQemu.None,
+		},
+		ciaoQemu.FSDevice{
+			Driver:        ciaoQemu.Virtio9P,
+			FSDriver:      ciaoQemu.Local,
+			ID:            fmt.Sprintf("ctr-%s-9p", fmt.Sprintf("%s.2", contID)),
+			Path:          fmt.Sprintf("%s.2", contRootFs),
+			MountTag:      "rootfs",
+			SecurityModel: ciaoQemu.None,
+		},
+		ciaoQemu.FSDevice{
+			Driver:        ciaoQemu.Virtio9P,
+			FSDriver:      ciaoQemu.Local,
+			ID:            fmt.Sprintf("extra-%s-9p", fmt.Sprintf("%s.1", volMountTag)),
+			Path:          fmt.Sprintf("%s.1", volHostPath),
+			MountTag:      fmt.Sprintf("%s.1", volMountTag),
+			SecurityModel: ciaoQemu.None,
+		},
+		ciaoQemu.FSDevice{
+			Driver:        ciaoQemu.Virtio9P,
+			FSDriver:      ciaoQemu.Local,
+			ID:            fmt.Sprintf("extra-%s-9p", fmt.Sprintf("%s.2", volMountTag)),
+			Path:          fmt.Sprintf("%s.2", volHostPath),
+			MountTag:      fmt.Sprintf("%s.2", volMountTag),
+			SecurityModel: ciaoQemu.None,
+		},
+	}
+
+	volumes := []Volume{
+		{
+			MountTag: fmt.Sprintf("%s.1", volMountTag),
+			HostPath: fmt.Sprintf("%s.1", volHostPath),
+		},
+		{
+			MountTag: fmt.Sprintf("%s.2", volMountTag),
+			HostPath: fmt.Sprintf("%s.2", volHostPath),
+		},
+	}
+
+	containers := []ContainerConfig{
+		{
+			ID:     fmt.Sprintf("%s.1", contID),
+			RootFs: fmt.Sprintf("%s.1", contRootFs),
+		},
+		{
+			ID:     fmt.Sprintf("%s.2", contID),
+			RootFs: fmt.Sprintf("%s.2", contRootFs),
+		},
+	}
+
+	podConfig := PodConfig{
+		ID:         podID,
+		RootFs:     podRootFs,
+		Volumes:    volumes,
+		Containers: containers,
+	}
+
+	testQemuAppend(t, podConfig, expectedOut, fsDev)
+}
+
+func TestQemuAppendConsoles(t *testing.T) {
+	podID := "testPodID"
+	contConsolePath := "testContConsolePath"
+
+	expectedOut := []ciaoQemu.Device{
+		ciaoQemu.SerialDevice{
+			Driver: ciaoQemu.VirtioSerial,
+			ID:     "serial0",
+		},
+		ciaoQemu.CharDevice{
+			Driver:   ciaoQemu.Console,
+			Backend:  ciaoQemu.Serial,
+			DeviceID: "console0",
+			ID:       "charconsole0",
+			Path:     contConsolePath,
+		},
+		ciaoQemu.CharDevice{
+			Driver:   ciaoQemu.Console,
+			Backend:  ciaoQemu.Socket,
+			DeviceID: "console1",
+			ID:       "charconsole1",
+			Path:     fmt.Sprintf("%s/%s/console.sock", runStoragePath, podID),
+		},
+	}
+
+	containers := []ContainerConfig{
+		{
+			Interactive: true,
+			Console:     contConsolePath,
+		},
+		{
+			Interactive: false,
+			Console:     "",
+		},
+	}
+
+	podConfig := PodConfig{
+		ID:         podID,
+		Containers: containers,
+	}
+
+	testQemuAppend(t, podConfig, expectedOut, consoleDev)
+}
+
+func TestQemuAppendImage(t *testing.T) {
+	var devices []ciaoQemu.Device
+
+	qemuConfig := newQemuConfig()
+	q := &qemu{
+		config: qemuConfig,
+	}
+
+	imageFile, err := os.Open(q.config.ImagePath)
+	if err != nil {
+		t.Fatal()
+	}
+	defer imageFile.Close()
+
+	imageStat, err := imageFile.Stat()
+	if err != nil {
+		t.Fatal()
+	}
+
+	expectedOut := []ciaoQemu.Device{
+		ciaoQemu.Object{
+			Driver:   ciaoQemu.NVDIMM,
+			Type:     ciaoQemu.MemoryBackendFile,
+			DeviceID: "nv0",
+			ID:       "mem0",
+			MemPath:  q.config.ImagePath,
+			Size:     (uint64)(imageStat.Size()),
+		},
+	}
+
+	podConfig := PodConfig{}
+
+	devices, err = q.appendImage(devices, podConfig)
+	if err != nil {
+		t.Fatal()
+	}
+
+	if reflect.DeepEqual(devices, expectedOut) == false {
+		t.Fatal()
+	}
+}
+
+func TestQemuInit(t *testing.T) {
+	qemuConfig := newQemuConfig()
+	q := &qemu{}
+
+	err := q.init(qemuConfig)
+	if err != nil {
+		t.Fatal()
+	}
+
+	if reflect.DeepEqual(qemuConfig, q.config) == false {
+		t.Fatal()
+	}
+
+	if reflect.DeepEqual(qemuConfig.HypervisorPath, q.path) == false {
+		t.Fatal()
+	}
+
+	if strings.Join(q.kernelParams, " ") != testQemuKernelParams {
+		t.Fatal()
+	}
+}
+
+func TestQemuSetCPUResources(t *testing.T) {
+	cpus := uint32(1)
+	cores := uint32(1)
+	sockets := uint32(1)
+	threads := uint32(1)
+
+	q := &qemu{}
+
+	expectedOut := ciaoQemu.SMP{
+		CPUs:    cpus,
+		Cores:   cores,
+		Sockets: sockets,
+		Threads: threads,
+	}
+
+	vmConfig := HardwareConfig{
+		CPUs:    fmt.Sprintf("%d", cpus),
+		Cores:   fmt.Sprintf("%d", cores),
+		Sockets: fmt.Sprintf("%d", sockets),
+		Threads: fmt.Sprintf("%d", threads),
+	}
+
+	podConfig := PodConfig{
+		VMConfig: vmConfig,
+	}
+
+	smp, err := q.setCPUResources(podConfig)
+	if err != nil {
+		t.Fatal()
+	}
+
+	if reflect.DeepEqual(smp, expectedOut) == false {
+		t.Fatal()
+	}
+}
+
+func TestQemuSetMemoryResources(t *testing.T) {
+	memSize := "1G"
+	memSlots := uint8(1)
+	memMax := "2G"
+
+	q := &qemu{}
+
+	expectedOut := ciaoQemu.Memory{
+		Size:   memSize,
+		Slots:  memSlots,
+		MaxMem: memMax,
+	}
+
+	vmConfig := HardwareConfig{
+		MemSize:  memSize,
+		MemSlots: fmt.Sprintf("%d", memSlots),
+		MemMax:   memMax,
+	}
+
+	podConfig := PodConfig{
+		VMConfig: vmConfig,
+	}
+
+	memory, err := q.setMemoryResources(podConfig)
+	if err != nil {
+		t.Fatal()
+	}
+
+	if reflect.DeepEqual(memory, expectedOut) == false {
+		t.Fatal()
+	}
+}
+
+func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []ciaoQemu.Device) {
+	q := &qemu{}
+
+	err := q.addDevice(devInfo, devType)
+	if err != nil {
+		t.Fatal()
+	}
+
+	if reflect.DeepEqual(q.qemuConfig.Devices, expected) == false {
+		t.Fatal()
+	}
+}
+
+func TestQemuAddDeviceFsDev(t *testing.T) {
+	mountTag := "testMountTag"
+	hostPath := "testHostPath"
+
+	expectedOut := []ciaoQemu.Device{
+		ciaoQemu.FSDevice{
+			Driver:        ciaoQemu.Virtio9P,
+			FSDriver:      ciaoQemu.Local,
+			ID:            fmt.Sprintf("extra-%s-9p", mountTag),
+			Path:          hostPath,
+			MountTag:      mountTag,
+			SecurityModel: ciaoQemu.None,
+		},
+	}
+
+	volume := Volume{
+		MountTag: mountTag,
+		HostPath: hostPath,
+	}
+
+	testQemuAddDevice(t, volume, fsDev, expectedOut)
+}
+
+func TestQemuAddDeviceSerialPordDev(t *testing.T) {
+	deviceID := "channelTest"
+	id := "charchTest"
+	hostPath := "/tmp/hyper_test.sock"
+	name := "sh.hyper.channel.test"
+
+	expectedOut := []ciaoQemu.Device{
+		ciaoQemu.CharDevice{
+			Driver:   ciaoQemu.VirtioSerialPort,
+			Backend:  ciaoQemu.Socket,
+			DeviceID: deviceID,
+			ID:       id,
+			Path:     hostPath,
+			Name:     name,
+		},
+	}
+
+	socket := Socket{
+		DeviceID: deviceID,
+		ID:       id,
+		HostPath: hostPath,
+		Name:     name,
+	}
+
+	testQemuAddDevice(t, socket, serialPortDev, expectedOut)
+}

--- a/spawner_test.go
+++ b/spawner_test.go
@@ -1,0 +1,97 @@
+//
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"reflect"
+	"testing"
+)
+
+var testSpawnerTypeList = []SpawnerType{
+	NsEnter,
+}
+
+func TestSpawnerTypeSet(t *testing.T) {
+	var s SpawnerType
+	var err error
+
+	for _, sType := range testSpawnerTypeList {
+		err = (&s).Set(string(sType))
+		if err != nil {
+			t.Fatal()
+		}
+
+		if s != sType {
+			t.Fatal()
+		}
+	}
+}
+
+func TestWrongSpawnerTypeSet(t *testing.T) {
+	var s SpawnerType
+
+	err := (&s).Set("noType")
+	if err == nil || s != "" {
+		t.Fatal()
+	}
+}
+
+func TestSpawnerTypeString(t *testing.T) {
+	for _, sType := range testSpawnerTypeList {
+		s := sType
+
+		result := (&s).String()
+		if result != string(NsEnter) {
+			t.Fatal()
+		}
+	}
+}
+
+func TestWrongSpawnerTypeString(t *testing.T) {
+	var s = SpawnerType("noType")
+
+	result := (&s).String()
+	if result != "" {
+		t.Fatal()
+	}
+}
+
+func testSpawnerNewSpawner(t *testing.T, sType SpawnerType, expected interface{}) {
+	spawner := newSpawner(sType)
+
+	if spawner == nil {
+		t.Fatal()
+	}
+
+	if reflect.DeepEqual(spawner, expected) == false {
+		t.Fatal()
+	}
+}
+
+func TestSpawnerNsEnterNewSpawner(t *testing.T) {
+	expectedOut := &nsenter{}
+
+	testSpawnerNewSpawner(t, NsEnter, expectedOut)
+}
+
+func TestWrongSpawnerNewSpawner(t *testing.T) {
+	spawner := newSpawner(SpawnerType("noType"))
+
+	if spawner != nil {
+		t.Fatal()
+	}
+}

--- a/virtc/main.go
+++ b/virtc/main.go
@@ -119,6 +119,48 @@ var podConfigFlags = []cli.Flag{
 		Value: "echo",
 		Usage: "the initial command to run on pod containers",
 	},
+
+	cli.StringFlag{
+		Name:  "vm-cpu-cpus",
+		Value: "",
+		Usage: "the number of cpus available for this pod",
+	},
+
+	cli.StringFlag{
+		Name:  "vm-cpu-cores",
+		Value: "",
+		Usage: "the number of cores available for this pod",
+	},
+
+	cli.StringFlag{
+		Name:  "vm-cpu-sockets",
+		Value: "",
+		Usage: "the number of sockets available for this pod",
+	},
+
+	cli.StringFlag{
+		Name:  "vm-cpu-threads",
+		Value: "",
+		Usage: "the number of threads available for this pod",
+	},
+
+	cli.StringFlag{
+		Name:  "vm-mem-size",
+		Value: "",
+		Usage: "the standard amount of memory available for this pod",
+	},
+
+	cli.StringFlag{
+		Name:  "vm-mem-slots",
+		Value: "",
+		Usage: "the number of memory slots available for this pod",
+	},
+
+	cli.StringFlag{
+		Name:  "vm-mem-max",
+		Value: "",
+		Usage: "the maximum amount of memory available for this pod",
+	},
 }
 
 func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
@@ -135,6 +177,13 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	hyperCtlSockType := context.String("hyper-ctl-sock-type")
 	hyperTtySockType := context.String("hyper-tty-sock-type")
 	initCmd := context.String("init-cmd")
+	cpuCPUs := context.String("vm-cpu-cpus")
+	cpuCores := context.String("vm-cpu-cores")
+	cpuSockets := context.String("vm-cpu-sockets")
+	cpuThreads := context.String("vm-cpu-threads")
+	memSize := context.String("vm-mem-size")
+	memSlots := context.String("vm-mem-slots")
+	memMax := context.String("vm-mem-max")
 	agentType, ok := context.Generic("agent").(*vc.AgentType)
 	if ok != true {
 		return vc.PodConfig{}, fmt.Errorf("Could not convert agent type")
@@ -218,7 +267,19 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 		agConfig = nil
 	}
 
+	vmConfig := vc.HardwareConfig{
+		CPUs:     cpuCPUs,
+		Cores:    cpuCores,
+		Sockets:  cpuSockets,
+		Threads:  cpuThreads,
+		MemSize:  memSize,
+		MemSlots: memSlots,
+		MemMax:   memMax,
+	}
+
 	podConfig := vc.PodConfig{
+		VMConfig: vmConfig,
+
 		HypervisorType:   vc.QemuHypervisor,
 		HypervisorConfig: hypervisorConfig,
 


### PR DESCRIPTION
Adding a new HardwareConfiguration structure in the existing PodConfig
allows to specify resources we need for every VM running a pod.
It fixes issue #1
