### PR TITLE
Simplify hyperstart and virtc command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ All following commands needs to be run as root. Currently, __virtc__ starts only
 
 #### Run a new pod (Create + Start)
 ```
-./virtc pod run --bundle="" --agent="hyperstart" --hyper-ctl-sock-name="/tmp/hyper.sock" --hyper-tty-sock-name="/tmp/tty.sock" --hyper-ctl-sock-type="unix" --hyper-tty-sock-type="unix" -volume="shared:/tmp/shared/hyper" -socket="channel0:charch0:/tmp/hyper.sock:sh.hyper.channel.0 channel1:charch1:/tmp/tty.sock:sh.hyper.channel.1" --init-cmd="stress --vm 12 --vm-bytes 128M --timeout 10s" -vm-vcpus=2 -vm-memory=2000
+./virtc pod run --bundle="" --agent="hyperstart" -volume="shared:/tmp/shared/hyper" --init-cmd="stress --vm 12 --vm-bytes 128M --timeout 10s" -vm-vcpus=2 -vm-memory=2000
 ```
 #### Create a new pod
 ```

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ All following commands needs to be run as root. Currently, __virtc__ starts only
 ```
 #### Create a new pod
 ```
-./virtc pod create --bundle="" --agent="hyperstart" --hyper-ctl-sock-name="/tmp/hyper.sock" --hyper-tty-sock-name="/tmp/tty.sock" --hyper-ctl-sock-type="unix" --hyper-tty-sock-type="unix" -volume="shared:/tmp/shared/hyper" -socket="channel0:charch0:/tmp/hyper.sock:sh.hyper.channel.0 channel1:charch1:/tmp/tty.sock:sh.hyper.channel.1" --init-cmd="stress --vm 12 --vm-bytes 128M --timeout 10s" -vm-vcpus=2 -vm-memory=2000
+./virtc pod create --bundle="" --agent="hyperstart" -volume="shared:/tmp/shared/hyper" --init-cmd="stress --vm 12 --vm-bytes 128M --timeout 10s" -cpus=2 -memory=2000
 ```
 This should generate that kind of output
 ```

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ All following commands needs to be run as root. Currently, __virtc__ starts only
 
 #### Run a new pod (Create + Start)
 ```
-./virtc pod run --bundle="" --agent="hyperstart" -volume="shared:/tmp/shared/hyper" --init-cmd="stress --vm 12 --vm-bytes 128M --timeout 10s" -vm-vcpus=2 -vm-memory=2000
+./virtc pod run --bundle="" --agent="hyperstart" -volume="shared:/tmp/shared/hyper" --init-cmd="stress --vm 12 --vm-bytes 128M --timeout 10s" -cpus=2 -memory=2000
 ```
 #### Create a new pod
 ```

--- a/agent.go
+++ b/agent.go
@@ -114,7 +114,7 @@ type agent interface {
 	// init().
 	// After init() is called, agent implementations should be initialized and ready
 	// to handle all other Agent interface methods.
-	init(config interface{}, hypervisor hypervisor) error
+	init(pod Pod, config interface{}) error
 
 	// start will start the agent on the host.
 	start() error

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -30,7 +30,6 @@ import (
 )
 
 var defaultSockPathTemplates = []string{"/tmp/hyper-pod-%s.sock", "/tmp/tty-pod%s.sock"}
-var defaultSocketType = "unix"
 var defaultChannelTemplate = "sh.hyper.channel.%d"
 var defaultDeviceIDTemplate = "channel%d"
 var defaultIDTemplate = "charch%d"
@@ -89,8 +88,6 @@ const (
 type HyperConfig struct {
 	SockCtlName string
 	SockTtyName string
-	SockCtlType string
-	SockTtyType string
 	Volumes     []Volume
 	Sockets     []Socket
 }
@@ -105,9 +102,7 @@ func (c *HyperConfig) validate(pod Pod) bool {
 		}
 
 		c.SockCtlName = podSocketPaths[0]
-		c.SockCtlType = defaultSocketType
 		c.SockTtyName = podSocketPaths[1]
-		c.SockTtyType = defaultSocketType
 
 		for i := 0; i < len(podSocketPaths); i++ {
 			s := Socket{
@@ -480,7 +475,7 @@ func (h *hyper) start() error {
 		return nil
 	}
 
-	h.cCtl, err = retryConnectSocket(1000, h.config.SockCtlType, h.config.SockCtlName)
+	h.cCtl, err = retryConnectSocket(1000, "unix", h.config.SockCtlName)
 	if err != nil {
 		return err
 	}
@@ -490,7 +485,7 @@ func (h *hyper) start() error {
 		return err
 	}
 
-	h.cTty, err = retryConnectSocket(1000, h.config.SockTtyType, h.config.SockTtyName)
+	h.cTty, err = retryConnectSocket(1000, "unix", h.config.SockTtyName)
 	if err != nil {
 		return err
 	}

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -22,7 +22,7 @@ type noopAgent struct {
 }
 
 // init initializes the Noop agent, i.e. it does nothing.
-func (n *noopAgent) init(config interface{}, hypervisor hypervisor) error {
+func (n *noopAgent) init(pod Pod, config interface{}) error {
 	return nil
 }
 

--- a/pod.go
+++ b/pod.go
@@ -700,7 +700,7 @@ func createPod(podConfig PodConfig) (*Pod, error) {
 		agentConfig = nil
 	}
 
-	err = p.agent.init(agentConfig, p.hypervisor)
+	err = p.agent.init(*p, agentConfig)
 	if err != nil {
 		p.storage.delete(p.id, nil)
 		return nil, err

--- a/sshd.go
+++ b/sshd.go
@@ -76,7 +76,7 @@ func execCmd(session *ssh.Session, cmd string) error {
 }
 
 // init is the agent initialization implementation for sshd.
-func (s *sshd) init(config interface{}, hypervisor hypervisor) error {
+func (s *sshd) init(pod Pod, config interface{}) error {
 	c := config.(SshdConfig)
 	if c.validate() == false {
 		return fmt.Errorf("Invalid configuration")

--- a/virtc/main.go
+++ b/virtc/main.go
@@ -90,18 +90,6 @@ var podConfigFlags = []cli.Flag{
 		Usage: "the hyperstart tty socket name",
 	},
 
-	cli.StringFlag{
-		Name:  "hyper-ctl-sock-type",
-		Value: "",
-		Usage: "the hyperstart control socket type",
-	},
-
-	cli.StringFlag{
-		Name:  "hyper-tty-sock-type",
-		Value: "",
-		Usage: "the hyperstart tty socket type",
-	},
-
 	cli.GenericFlag{
 		Name:  "volume",
 		Value: new(vc.Volumes),
@@ -144,8 +132,6 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 	sshdKey := context.String("sshd-auth-file")
 	hyperCtlSockName := context.String("hyper-ctl-sock-name")
 	hyperTtySockName := context.String("hyper-tty-sock-name")
-	hyperCtlSockType := context.String("hyper-ctl-sock-type")
-	hyperTtySockType := context.String("hyper-tty-sock-type")
 	initCmd := context.String("init-cmd")
 	vmVCPUs := context.Uint("vm-vcpus")
 	vmMemory := context.Uint("vm-memory")
@@ -224,8 +210,6 @@ func buildPodConfig(context *cli.Context) (vc.PodConfig, error) {
 		agConfig = vc.HyperConfig{
 			SockCtlName: hyperCtlSockName,
 			SockTtyName: hyperTtySockName,
-			SockCtlType: hyperCtlSockType,
-			SockTtyType: hyperTtySockType,
 			Volumes:     *volumes,
 			Sockets:     *sockets,
 		}

--- a/virtc/main.go
+++ b/virtc/main.go
@@ -121,13 +121,13 @@ var podConfigFlags = []cli.Flag{
 	},
 
 	cli.UintFlag{
-		Name:  "vm-vcpus",
+		Name:  "cpus",
 		Value: 0,
 		Usage: "the number of virtual cpus available for this pod",
 	},
 
 	cli.UintFlag{
-		Name:  "vm-memory",
+		Name:  "memory",
 		Value: 0,
 		Usage: "the amount of memory available for this pod in MiB",
 	},


### PR DESCRIPTION
* We only support unix sockets
* `-vm-vcpus` is now `-cpus`
* `-vm-memory` is now `memory`
* Make all virtc socket virtc command line settings optional