### PR TITLE
Preparation for bind mounting the pod containers rootfs

### DIFF
--- a/syscall.go
+++ b/syscall.go
@@ -1,0 +1,75 @@
+//
+// Copyright 2015 The rkt Authors
+// Copyright (c) 2016 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package virtcontainers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+const mountPerm = os.FileMode(0755)
+
+// bindMount bind mounts a source in to a destination. This will
+// do some bookkeeping:
+// * evaluate all symlinks
+// * ensure the source exists
+// * recursively create the destination
+func bindMount(source, destination string) error {
+	absSource, err := filepath.EvalSymlinks(source)
+	if err != nil {
+		return fmt.Errorf("Could not resolve symlink for source %v", source)
+	}
+
+	if err := ensureDestinationExists(absSource, destination); err != nil {
+		return fmt.Errorf("Could not create destination mount point: %v", destination)
+	} else if err := syscall.Mount(absSource, destination, "bind", syscall.MS_BIND, ""); err != nil {
+		return fmt.Errorf("Could not bind mount %v to %v", absSource, destination)
+	}
+
+	return nil
+}
+
+// ensureDestinationExists will recursively create a given mountpoint. If directories
+// are created, their permissions are initialized to mountPerm
+func ensureDestinationExists(source, destination string) error {
+	fileInfo, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("could not stat source location: %v", source)
+	}
+
+	targetPathParent, _ := filepath.Split(destination)
+	if err := os.MkdirAll(targetPathParent, mountPerm); err != nil {
+		return fmt.Errorf("could not create parent directory: %v", targetPathParent)
+	}
+
+	if fileInfo.IsDir() {
+		if err := os.Mkdir(destination, mountPerm); !os.IsExist(err) {
+			return err
+		}
+	} else {
+		file, err := os.OpenFile(destination, os.O_CREATE, mountPerm)
+		if err != nil {
+			return err
+		}
+
+		file.Close()
+	}
+	return nil
+}

--- a/virtc/main.go
+++ b/virtc/main.go
@@ -398,8 +398,62 @@ var statusPodCommand = cli.Command{
 	},
 }
 
+func glogFlagShim(fakeVals map[string]string) {
+	flag.VisitAll(func(fl *flag.Flag) {
+		if val, ok := fakeVals[fl.Name]; ok {
+			fl.Value.Set(val)
+		}
+	})
+}
+
+func glogShim(c *cli.Context) {
+	_ = flag.CommandLine.Parse([]string{})
+	glogFlagShim(map[string]string{
+		"v":                fmt.Sprint(c.Int("v")),
+		"logtostderr":      fmt.Sprint(c.Bool("logtostderr")),
+		"stderrthreshold":  fmt.Sprint(c.Int("stderrthreshold")),
+		"alsologtostderr":  fmt.Sprint(c.Bool("alsologtostderr")),
+		"vmodule":          c.String("vmodule"),
+		"log_dir":          c.String("log_dir"),
+		"log_backtrace_at": c.String("log_backtrace_at"),
+	})
+}
+
+var glogFlags = []cli.Flag{
+	cli.IntFlag{
+		Name: "v", Value: 0, Usage: "log level for V logs",
+	},
+	cli.BoolFlag{
+		Name: "logtostderr", Usage: "log to standard error instead of files",
+	},
+	cli.IntFlag{
+		Name:  "stderrthreshold",
+		Usage: "logs at or above this threshold go to stderr",
+	},
+	cli.BoolFlag{
+		Name: "alsologtostderr", Usage: "log to standard error as well as files",
+	},
+	cli.StringFlag{
+		Name:  "vmodule",
+		Usage: "comma-separated list of pattern=N settings for file-filtered logging",
+	},
+	cli.StringFlag{
+		Name: "log_dir", Usage: "If non-empty, write log files in this directory",
+	},
+	cli.StringFlag{
+		Name:  "log_backtrace_at",
+		Usage: "when logging hits line file:N, emit a stack trace",
+		Value: ":0",
+	},
+}
+
 func main() {
 	flag.Parse()
+
+	cli.VersionFlag = cli.BoolFlag{
+		Name:  "version",
+		Usage: "print the version",
+	}
 
 	virtc := cli.NewApp()
 	virtc.Name = "VirtContainers CLI"
@@ -419,6 +473,12 @@ func main() {
 				statusPodCommand,
 			},
 		},
+	}
+
+	virtc.Flags = append(virtc.Flags, glogFlags...)
+	virtc.Action = func(c *cli.Context) error {
+		glogShim(c)
+		return nil
 	}
 
 	err := virtc.Run(os.Args)


### PR DESCRIPTION
* Add syscall.go for wrapping system calls. We define a "smart" bind mount there for now.
* Enable glog and urfave/cli at the same time, so that we can debug virtc