### PR TITLE
Fix VM issue related to wrong mount tag "rootfs"

### DIFF
--- a/qemu.go
+++ b/qemu.go
@@ -189,12 +189,11 @@ func (q *qemu) appendFSDevices(devices []ciaoQemu.Device, podConfig PodConfig) [
 
 		devices = append(devices,
 			ciaoQemu.FSDevice{
-				Driver:   ciaoQemu.Virtio9P,
-				FSDriver: ciaoQemu.Local,
-				ID:       fmt.Sprintf("ctr-%s-9p", c.ID),
-				Path:     c.RootFs,
-				//MountTag:      fmt.Sprintf("ctr-rootfs-%s", c.ID),
-				MountTag:      "rootfs", // CC hack, systemd mounts rootfs.
+				Driver:        ciaoQemu.Virtio9P,
+				FSDriver:      ciaoQemu.Local,
+				ID:            fmt.Sprintf("ctr-%s-9p", c.ID),
+				Path:          c.RootFs,
+				MountTag:      fmt.Sprintf("ctr-rootfs-%s", c.ID),
 				SecurityModel: ciaoQemu.None,
 			},
 		)

--- a/qemu_test.go
+++ b/qemu_test.go
@@ -170,7 +170,7 @@ func TestQemuAppendFSDevices(t *testing.T) {
 			FSDriver:      ciaoQemu.Local,
 			ID:            fmt.Sprintf("ctr-%s-9p", fmt.Sprintf("%s.1", contID)),
 			Path:          fmt.Sprintf("%s.1", contRootFs),
-			MountTag:      "rootfs",
+			MountTag:      fmt.Sprintf("ctr-rootfs-%s.1", contID),
 			SecurityModel: ciaoQemu.None,
 		},
 		ciaoQemu.FSDevice{
@@ -178,7 +178,7 @@ func TestQemuAppendFSDevices(t *testing.T) {
 			FSDriver:      ciaoQemu.Local,
 			ID:            fmt.Sprintf("ctr-%s-9p", fmt.Sprintf("%s.2", contID)),
 			Path:          fmt.Sprintf("%s.2", contRootFs),
-			MountTag:      "rootfs",
+			MountTag:      fmt.Sprintf("ctr-rootfs-%s.2", contID),
 			SecurityModel: ciaoQemu.None,
 		},
 		ciaoQemu.FSDevice{


### PR DESCRIPTION
Qemu command line create some mount tag with an hardcoded "rootfs" name. This was an issue because the systemd process tries to mount a rootfs mount tag by default. We want our containers mount tags to have a different name. Also, this patch allows each mount tag to be different for each container.