### PR TITLE
agent: Simplify the interface

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -123,17 +123,17 @@ type agent interface {
 	stopAgent() error
 
 	// exec will tell the agent to run a command in an already running container.
-	exec(podID string, contID string, cmd Cmd) error
+	exec(pod Pod, container Container, cmd Cmd) error
 
 	// startPod will tell the agent to start all containers related to the Pod.
 	startPod(config PodConfig) error
 
 	// stopPod will tell the agent to stop all containers related to the Pod.
-	stopPod(config PodConfig) error
+	stopPod(pod Pod) error
 
 	// startContainer will tell the agent to start a container related to a Pod.
-	startContainer(podConfig PodConfig, contConfig ContainerConfig) error
+	startContainer(pod Pod, contConfig ContainerConfig) error
 
 	// stopContainer will tell the agent to stop a container related to a Pod.
-	stopContainer(podConfig PodConfig, contConfig ContainerConfig) error
+	stopContainer(pod Pod, container Container) error
 }

--- a/container.go
+++ b/container.go
@@ -262,7 +262,7 @@ func (c *Container) start() error {
 		return err
 	}
 
-	err = c.pod.agent.startContainer(*(c.pod.config), *(c.config))
+	err = c.pod.agent.startContainer(*c.pod, *(c.config))
 	if err != nil {
 		c.stop()
 		return err
@@ -305,7 +305,7 @@ func (c *Container) stop() error {
 		return err
 	}
 
-	err = c.pod.agent.stopContainer(*(c.pod.config), *(c.config))
+	err = c.pod.agent.stopContainer(*c.pod, *c)
 	if err != nil {
 		return err
 	}
@@ -342,7 +342,7 @@ func (c *Container) enter(cmd Cmd) error {
 		return err
 	}
 
-	err = c.pod.agent.exec(c.pod.id, c.id, cmd)
+	err = c.pod.agent.exec(*c.pod, *c, cmd)
 	if err != nil {
 		return err
 	}

--- a/hyperstart.go
+++ b/hyperstart.go
@@ -225,14 +225,14 @@ func (h *hyper) startAgent() error {
 }
 
 // exec is the agent command execution implementation for hyperstart.
-func (h *hyper) exec(podID string, contID string, cmd Cmd) error {
+func (h *hyper) exec(pod Pod, container Container, cmd Cmd) error {
 	process, err := h.buildHyperContainerProcess(cmd)
 	if err != nil {
 		return err
 	}
 
 	execInfo := ExecInfo{
-		Container: contID,
+		Container: container.id,
 		Process:   process,
 	}
 
@@ -289,7 +289,7 @@ func (h *hyper) startPod(config PodConfig) error {
 }
 
 // stopPod is the agent Pod stopping implementation for hyperstart.
-func (h *hyper) stopPod(config PodConfig) error {
+func (h *hyper) stopPod(pod Pod) error {
 	_, err := h.hyperstart.SendCtlMessage(hyperstart.DestroyPod, nil)
 	if err != nil {
 		return err
@@ -311,7 +311,7 @@ func (h *hyper) stopAgent() error {
 }
 
 // startContainer is the agent Container starting implementation for hyperstart.
-func (h *hyper) startContainer(podConfig PodConfig, contConfig ContainerConfig) error {
+func (h *hyper) startContainer(pod Pod, contConfig ContainerConfig) error {
 	process, err := h.buildHyperContainerProcess(contConfig.Cmd)
 	if err != nil {
 		return err
@@ -338,8 +338,8 @@ func (h *hyper) startContainer(podConfig PodConfig, contConfig ContainerConfig) 
 }
 
 // stopContainer is the agent Container stopping implementation for hyperstart.
-func (h *hyper) stopContainer(podConfig PodConfig, contConfig ContainerConfig) error {
-	payload := []byte(fmt.Sprintf("{\"container\":\"%s\",\"signal\":\"9\"}", contConfig.ID))
+func (h *hyper) stopContainer(pod Pod, container Container) error {
+	payload := []byte(fmt.Sprintf("{\"container\":\"%s\",\"signal\":\"9\"}", container.id))
 
 	_, err := h.hyperstart.SendCtlMessage(hyperstart.KillContainer, payload)
 	if err != nil {

--- a/noop_agent.go
+++ b/noop_agent.go
@@ -32,7 +32,7 @@ func (n *noopAgent) startAgent() error {
 }
 
 // exec is the Noop agent command execution implementation. It does nothing.
-func (n *noopAgent) exec(podID string, contID string, cmd Cmd) error {
+func (n *noopAgent) exec(pod Pod, container Container, cmd Cmd) error {
 	return nil
 }
 
@@ -42,7 +42,7 @@ func (n *noopAgent) startPod(config PodConfig) error {
 }
 
 // stopPod is the Noop agent Pod stopping implementation. It does nothing.
-func (n *noopAgent) stopPod(config PodConfig) error {
+func (n *noopAgent) stopPod(pod Pod) error {
 	return nil
 }
 
@@ -52,11 +52,11 @@ func (n *noopAgent) stopAgent() error {
 }
 
 // startContainer is the Noop agent Container starting implementation. It does nothing.
-func (n *noopAgent) startContainer(podConfig PodConfig, contConfig ContainerConfig) error {
+func (n *noopAgent) startContainer(pod Pod, contConfig ContainerConfig) error {
 	return nil
 }
 
 // stopContainer is the Noop agent Container stopping implementation. It does nothing.
-func (n *noopAgent) stopContainer(podConfig PodConfig, contConfig ContainerConfig) error {
+func (n *noopAgent) stopContainer(pod Pod, container Container) error {
 	return nil
 }

--- a/pod.go
+++ b/pod.go
@@ -992,7 +992,7 @@ func (p *Pod) stop() error {
 		return err
 	}
 
-	err = p.agent.stopPod(*p.config)
+	err = p.agent.stopPod(*p)
 	if err != nil {
 		return err
 	}

--- a/sshd.go
+++ b/sshd.go
@@ -129,7 +129,7 @@ func (s *sshd) startAgent() error {
 }
 
 // exec is the agent command execution implementation for sshd.
-func (s *sshd) exec(podID string, contID string, cmd Cmd) error {
+func (s *sshd) exec(pod Pod, container Container, cmd Cmd) error {
 	session, err := s.client.NewSession()
 	if err != nil {
 		return fmt.Errorf("Failed to create session")
@@ -154,7 +154,7 @@ func (s *sshd) startPod(config PodConfig) error {
 }
 
 // stopPod is the agent Pod stopping implementation for sshd.
-func (s *sshd) stopPod(config PodConfig) error {
+func (s *sshd) stopPod(pod Pod) error {
 	return nil
 }
 
@@ -164,11 +164,11 @@ func (s *sshd) stopAgent() error {
 }
 
 // startContainer is the agent Container starting implementation for sshd.
-func (s *sshd) startContainer(podConfig PodConfig, contConfig ContainerConfig) error {
+func (s *sshd) startContainer(pod Pod, contConfig ContainerConfig) error {
 	return nil
 }
 
 // stopContainer is the agent Container stopping implementation for sshd.
-func (s *sshd) stopContainer(podConfig PodConfig, contConfig ContainerConfig) error {
+func (s *sshd) stopContainer(pod Pod, container Container) error {
 	return nil
 }


### PR DESCRIPTION
We take a Pod argument whenever we want to touch a Pod, and
a Container when we need to reach a container within that pod.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>