### PR TITLE
api: Coarse locking

### DIFF
--- a/pod_test.go
+++ b/pod_test.go
@@ -238,7 +238,7 @@ func TestPodFileState(t *testing.T) {
 	}
 }
 
-var podFileLock = filepath.Join(runStoragePath, testPodID, lockFile)
+var podFileLock = filepath.Join(runStoragePath, testPodID, lockFileName)
 
 func TestPodFileLock(t *testing.T) {
 	err := testPodFile(t, lockFileType, podFileLock)


### PR DESCRIPTION
In order to simplify the pod code, we push the pod locking in api.go,
the only external virtcontainers API.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>
Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>