### PR TITLE
api: Rename ContainerStatus

### DIFF
--- a/api.go
+++ b/api.go
@@ -444,9 +444,9 @@ func EnterContainer(podID, containerID string, cmd Cmd) (*Container, error) {
 	return c, nil
 }
 
-// ContainerStatus is the virtcontainers container status entry point.
-// ContainerStatus returns a detailed container status.
-func ContainerStatus(podID, containerID string) error {
+// StatusContainer is the virtcontainers container status entry point.
+// StatusContainer returns a detailed container status.
+func StatusContainer(podID, containerID string) error {
 	fs := filesystem{}
 
 	w := tabwriter.NewWriter(os.Stdout, 2, 8, 1, '\t', 0)

--- a/virtc/main.go
+++ b/virtc/main.go
@@ -486,7 +486,7 @@ func enterContainer(context *cli.Context) error {
 }
 
 func statusContainer(context *cli.Context) error {
-	err := vc.ContainerStatus(context.String("pod-id"), context.String("id"))
+	err := vc.StatusContainer(context.String("pod-id"), context.String("id"))
 	if err != nil {
 		return fmt.Errorf("Could not get container status: %s", err)
 	}


### PR DESCRIPTION
To StatusContainer for both consistency and godoc compliance
sake.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>